### PR TITLE
10 - 지난 이미지 삭제를 위한 deploy.yml 명령어 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,4 +51,5 @@ jobs:
             cd /root/devti
             docker compose pull web
             docker compose up -d
+            docker container prune -f
             docker image prune -f


### PR DESCRIPTION
**#️⃣ 어떤 기능인가요?**

이전 컨테이너에 의해 참조되는 dangling image가 남아있는 경우가 발생하였습니다. 그래서 사용하지 않는 컨테이너를 삭제하는 명령어를  deploy.yml에 추가하여 CD 과정에서 사용하지 않는 이미지는 모두 삭제되게 하였습니다.

**#️⃣ 팀원 확인 사항**

main에 merge 후 서버 내에 현재 사용중인 이미지만 뜨는지 확인해도 좋을 것 같습니다.

**#️⃣ 작업 상세 내용**

- [x]  deploy.yml에 docker container prune -f 추가