### PR TITLE
24 - 프론트엔드 로컬 개발 환경 CORS/CSRF 설정

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -195,17 +195,18 @@ ATOMIC_REQUEST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # CORS 설정
+CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
     "https://devti-one.vercel.app",
     "https://www.devti.site",
+    "http://localhost:5173",
 ]
 
 CSRF_TRUSTED_ORIGINS = [
     "https://devti.site",
     "https://www.devti.site",
     "https://devti-one.vercel.app",
+    "http://localhost:5173",
 ]
 
 # 세션/CSRF 쿠키를 HTTPS 전용으로 설정


### PR DESCRIPTION
**#️⃣ 어떤 기능인가요?**

Vite를 사용하는 프론트엔드 로컬 개발 환경에서 CORS 접근이 가능하도록 개선

**#️⃣ 작업 상세 내용**

- [x] CORS_ALLOWED_ORIGINS: localhost:3000 -> localhost:5173으로 변경
- [x] CSRF_TRUSTED_ORIGINS: localhost:5173 추가
- [x] CORS_ALLOW_CREDENTIALS: True로 CSRF 쿠키를 사용할 수 있도록 설정