### PR TITLE
42 - 프로필 작성 여부 검증 오류 수정

### DIFF
--- a/src/users/models.py
+++ b/src/users/models.py
@@ -55,22 +55,21 @@ class User(AbstractBaseUser, PermissionsMixin):
         작성 완료한 파트별 프로필 목록 반환
         """
         parts = []
-        try:
-            profile = self.profile_set.first()
-
-            if hasattr(profile, "profilepm") and profile.profilepm is not None:
-                parts.append("PM")
-            if hasattr(profile, "profilefe") and profile.profilefe is not None:
-                parts.append("FE")
-            if hasattr(profile, "profilebe") and profile.profilebe is not None:
-                parts.append("BE")
-            if hasattr(profile, "profilede") and profile.profilede is not None:
-                parts.append("DE")
-
-            return parts
-
-        except Exception:
+        if not self.profile_set.exists():  # 공통 프로필이 없는 경우
             return []
+
+        profile = self.profile_set.first()
+
+        if profile.profilepm_set.exists():
+            parts.append("PM")
+        if profile.profilefe_set.exists():
+            parts.append("FE")
+        if profile.profilebe_set.exists():
+            parts.append("BE")
+        if profile.profilede_set.exists():
+            parts.append("DE")
+
+        return parts
 
 
 class Profile(models.Model):
@@ -138,6 +137,7 @@ class ProfileBE(models.Model):
     strength = models.TextField(null=True)
     github_url = models.URLField(max_length=200, null=True)
     development_score = models.JSONField(null=True, default=list)
+
     class Meta:
         db_table = "profile_be"
 


### PR DESCRIPTION
**#️⃣ 어떤 기능인가요?**

`validate-code` API 호출 시, 사용자가 파트별 프로필을 작성했음에도 프로필이 없다는 `400` 에러가 발생하는 버그를 수정 

**#️⃣ 작업 상세 내용**

- [x] `User.available_parts` 속성의 프로필 존재 여부 확인 로직을 `hasattr`에서 `_set.exists()`로 수정