### PR TITLE
48 - 참가자 삭제 이벤트 브로드캐스팅

### DIFF
--- a/src/matchings/room/consumers.py
+++ b/src/matchings/room/consumers.py
@@ -96,6 +96,12 @@ class RoomConsumer(AsyncJsonWebsocketConsumer):
         '''
         await self.send_json(event)
 
+    async def participant_delete(self, event):
+        '''
+        participant.delete 이벤트 핸들러
+        '''
+        await self.send_json(event)
+
     async def room_state_change(self, event):
         '''
         room.state_change 이벤트 핸들러


### PR DESCRIPTION
**#️⃣ 어떤 기능인가요?**

- 매칭룸에서 참가자가 삭제되었을 때, 다른 참가자에게 실시간 반영이 가능하도록 웹소켓 이벤트 브로드캐스트

**#️⃣ 작업 상세 내용**

- [x] `src/users/user/views.py.delete_participant` 에 브로드캐스트 로직 추가
- [x] `src/matchings/room/consumers.py`에 `participant_delete` 이벤트 핸들러 추가